### PR TITLE
Close version 0.3.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Currently, the package is available in Github Packages, so make sure to have the
 <dependency>
   <groupId>ai.pluggy</groupId>
   <artifactId>pluggy-java</artifactId>
-  <version>0.4.0-SNAPSHOT</version>
+  <version>0.3.1</version>
 </dependency>
 ```
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Currently, the package is available in Github Packages, so make sure to have the
 <dependency>
   <groupId>ai.pluggy</groupId>
   <artifactId>pluggy-java</artifactId>
-  <version>0.3.0</version>
+  <version>0.4.0-SNAPSHOT</version>
 </dependency>
 ```
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
   <groupId>ai.pluggy</groupId>
   <artifactId>pluggy-java</artifactId>
-  <version>0.4.0-SNAPSHOT</version>
+  <version>0.3.1</version>
 
   <packaging>jar</packaging>
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
   <groupId>ai.pluggy</groupId>
   <artifactId>pluggy-java</artifactId>
-  <version>0.3.0</version>
+  <version>0.4.0-SNAPSHOT</version>
 
   <packaging>jar</packaging>
 

--- a/src/main/java/ai/pluggy/client/request/TransactionsSearchRequest.java
+++ b/src/main/java/ai/pluggy/client/request/TransactionsSearchRequest.java
@@ -3,12 +3,11 @@ package ai.pluggy.client.request;
 import static ai.pluggy.utils.Asserts.assertNotNull;
 import static ai.pluggy.utils.Asserts.assertValidDateString;
 
-import java.time.format.DateTimeFormatter;
 import java.util.HashMap;
 
 public class TransactionsSearchRequest extends HashMap<String, Object> {
 
-  public static final DateTimeFormatter DATE_PARAM_FORMAT = DateTimeFormatter.ISO_DATE;
+  public static final String DATE_PARAM_FORMAT_ISO = "yyyy-MM-dd";
 
   /**
    * @param fromDate String - from date in 'YYYY-MM-DD' format
@@ -52,7 +51,7 @@ public class TransactionsSearchRequest extends HashMap<String, Object> {
 
 
   private void validateDateString(String dateString, String name) {
-    assertValidDateString(dateString, DATE_PARAM_FORMAT, name);
+    assertValidDateString(dateString, DATE_PARAM_FORMAT_ISO, name);
   }
 
   public Integer getPage() {

--- a/src/main/java/ai/pluggy/client/response/CreditData.java
+++ b/src/main/java/ai/pluggy/client/response/CreditData.java
@@ -1,5 +1,8 @@
 package ai.pluggy.client.response;
 
+import lombok.Data;
+
+@Data
 public class CreditData {
 
   String level;

--- a/src/main/java/ai/pluggy/utils/Asserts.java
+++ b/src/main/java/ai/pluggy/utils/Asserts.java
@@ -35,21 +35,31 @@ public abstract class Asserts {
 
 
   /**
-   * Asserts that a value is a valid URL.
+   * Asserts that a string value is a valid Date string, according to a specified dateFormatPattern.
+   * The pattern must be supported by DateTimeFormatter (See: <a href="https://docs.oracle.com/javase/8/docs/api/java/time/format/DateTimeFormatter.html"/>)
    *
-   * @param value the value to check.
-   * @param name  the name of the parameter, used when creating the exception message.
+   * @param value             the value to check.
+   * @param dateFormatPattern the date string pattern to use for validating the date.
+   * @param name              the name of the parameter, used when creating the exception message.
    * @throws IllegalArgumentException if the value is null or is not a valid URL.
    */
-  public static void assertValidDateString(String value, DateTimeFormatter dateFormat,
+  public static void assertValidDateString(String value, String dateFormatPattern,
     String name) {
-    String invalidValueErrorMsg = String.format(
-      "Invalid date string format '%s' for field '%s', expected format: '%s'!",
-      value, name, dateFormat);
+    DateTimeFormatter dateFormat;
+    try {
+      dateFormat = DateTimeFormatter.ofPattern(dateFormatPattern);
+    } catch (IllegalArgumentException e) {
+      String invalidDatePatternErrorMsg = String.format(
+        "Invalid dateFormatPattern string: '%s'", dateFormatPattern);
+      throw new IllegalArgumentException(invalidDatePatternErrorMsg);
+    }
 
     try {
       LocalDate.parse(value, dateFormat);
     } catch (DateTimeParseException e) {
+      String invalidValueErrorMsg = String.format(
+        "Invalid date string format '%s' for field '%s', expected format: '%s'!",
+        value, name, dateFormatPattern);
       throw new IllegalArgumentException(invalidValueErrorMsg);
     }
   }

--- a/src/test/java/ai/pluggy/client/integration/CreateItemTest.java
+++ b/src/test/java/ai/pluggy/client/integration/CreateItemTest.java
@@ -37,7 +37,7 @@ public class CreateItemTest extends BaseApiIntegrationTest {
     assertEquals(itemResponse1.getConnectorId(), connectorId);
 
     // run request with 'connectorId', 'parameters', 'webhookUrl' params
-    String webhookUrl = "localhost:9999";
+    String webhookUrl = "https://www.test.com/";
     CreateItemRequest createItemRequestWithWebhook = new CreateItemRequest(connectorId,
       parametersMap, webhookUrl);
     Response<ItemResponse> itemRequestWithWebhookResponse = client.service()
@@ -68,5 +68,25 @@ public class CreateItemTest extends BaseApiIntegrationTest {
     ErrorResponse errorResponse = client.parseError(itemRequestResponse);
     assertNotNull(errorResponse);
     assertEquals(errorResponse.getCode(), 400);
+
+    // webhookUrl param 'localhost' is invalid, expect error 400
+    String localWebhookUrl = "localhost:9999";
+    CreateItemRequest createItemRequestWithLocalWebhook = new CreateItemRequest(connectorId,
+      parametersMap, localWebhookUrl);
+    Response<ItemResponse> itemRequestWithLocalWebhookResponse = client.service()
+      .createItem(createItemRequestWithLocalWebhook).execute();
+    ErrorResponse localWebhookErrorResponse = client.parseError(itemRequestWithLocalWebhookResponse);
+    assertNotNull(localWebhookErrorResponse);
+    assertEquals(localWebhookErrorResponse.getCode(), 400);
+
+    // webhookUrl param http is invalid, expect error 400
+    String httpWebhookUrl = "http://www.test.com";
+    CreateItemRequest createItemRequestWithHttpWebhook = new CreateItemRequest(connectorId,
+      parametersMap, httpWebhookUrl);
+    Response<ItemResponse> itemRequestWithHttpWebhookResponse = client.service()
+      .createItem(createItemRequestWithHttpWebhook).execute();
+    ErrorResponse httpWebhookErrorResponse = client.parseError(itemRequestWithHttpWebhookResponse);
+    assertNotNull(httpWebhookErrorResponse);
+    assertEquals(httpWebhookErrorResponse.getCode(), 400);
   }
 }

--- a/src/test/java/ai/pluggy/client/integration/GetTransactionsTest.java
+++ b/src/test/java/ai/pluggy/client/integration/GetTransactionsTest.java
@@ -13,7 +13,6 @@ import java.util.Comparator;
 import java.util.List;
 import java.util.stream.Collectors;
 import lombok.SneakyThrows;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import retrofit2.Response;
 
@@ -111,7 +110,6 @@ public class GetTransactionsTest extends BaseApiIntegrationTest {
         transactionsFilteredCount, allTransactionsCount, dateFilters));
   }
 
-  @Disabled // TODO reenable test until 'pageSize' param is fixed in test URL environment
   @SneakyThrows
   @Test
   void getTransactions_byExistingAccountId_withPageFilters_ok() {

--- a/src/test/java/ai/pluggy/client/integration/UpdateItemTest.java
+++ b/src/test/java/ai/pluggy/client/integration/UpdateItemTest.java
@@ -31,7 +31,7 @@ public class UpdateItemTest extends BaseApiIntegrationTest {
 
     // build update item request
     ParametersMap newParameters = ParametersMap.map("user", "qwe");
-    String newWebhookUrl = "localhost:3000";
+    String newWebhookUrl = "https://www.test.com";
     UpdateItemRequest updateItemRequest = UpdateItemRequest.builder()
       .webhookUrl(newWebhookUrl)
       .build();
@@ -60,7 +60,7 @@ public class UpdateItemTest extends BaseApiIntegrationTest {
     ItemResponse createdItemResponse = createPluggyBankItem(client);
 
     // build update item request
-    String newWebhookUrl = "localhost:3000";
+    String newWebhookUrl = "https://www.test2.com";
     UpdateItemRequest updateItemRequest = UpdateItemRequest.builder()
       .webhookUrl(newWebhookUrl)
       .build();


### PR DESCRIPTION
* Reenable disabled test `getTransactions_byExistingAccountId_withPageFilters_ok`
* Hotfix: add getters & setters to `CreditData` response object.
* improve `Asserts.assertValidDateString()` validation error message.